### PR TITLE
Fix #1 : Add return statement at the end of non-void function.

### DIFF
--- a/Darts.xs
+++ b/Darts.xs
@@ -24,6 +24,7 @@ static IV da_make(AV *av){
 
 static int da_free(IV dpi){
     delete INT2PTR(Darts::DoubleArray *, dpi);
+    return 0;
 }
 
 static IV da_open(char *filename){


### PR DESCRIPTION
This change will resolves the segmentation faults.

Note:
If a non-void function reaches at the end without return statement,
it is **"undefined behavior".**

In this issue case, my investigation, the optimizer (-O2) generated infinite loops inside xs_free function and it free (delete) same region twice.

compile with g++ -S ...

```
        .type   _ZL22XS_Text__Darts_xs_freeP11interpreterP2cv, @function
_ZL22XS_Text__Darts_xs_freeP11interpreterP2cv:
.LVL115:
.LFB1344:
(snip)
.L56:
        .loc 3 130 5 is_stmt 1 discriminator 4 view .LVU235
.LBB792:
.LBI792:
        .loc 3 25 12 discriminator 4 view .LVU236
.LBB793:
        .loc 3 26 5 discriminator 4 view .LVU237
        .loc 3 26 12 is_stmt 0 discriminator 4 view .LVU238
        movq    (%r12), %rax
        movq    %r12, %rdi
        call    *8(%rax)
.LVL136:
.L59:
        .loc 3 26 12 discriminator 4 view .LVU239
.LBE793:
.LBE792:
        .loc 1 314 2 discriminator 1 view .LVU240
        call    pthread_getspecific@PLT
.LVL137:
        movl    0(%rbp), %edi
        call    pthread_getspecific@PLT
.LVL138:
        jmp     .L56
```

call    *8(%rax) :  maybe calling delete operator.
and then by "jmp .L56" instruction, the above line is executed at least twice (it is really infinite loop, but the second call will cause segmentation fault and stop).